### PR TITLE
Set java source and target compatibility to 1.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,11 @@ signing {
     sign configurations.archives
 }
 
+compileJava {
+  sourceCompatibility = 1.6
+  targetCompatibility = 1.6
+}
+
 uploadArchives {
     repositories {
         mavenDeployer {


### PR DESCRIPTION
Version 1.1 of the plugin is not compatible anymore with projects using a JDK < 1.8 as it was build with java 8. 
