### PR TITLE
Fixed sourceCompatibility and targetCompatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,10 +38,8 @@ signing {
     sign configurations.archives
 }
 
-compileJava {
-  sourceCompatibility = 1.6
-  targetCompatibility = 1.6
-}
+sourceCompatibility = 1.6
+targetCompatibility = 1.6
 
 uploadArchives {
     repositories {


### PR DESCRIPTION
Previous patch did not work, the sourceCompatibility and targetCompatibility settings do not work when placed  in a compileJava block.  Why?  Don't know..
