### PR TITLE
Support Java 8 by upgrading Felix SCR dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,8 +13,8 @@ dependencies {
     compile gradleApi()
     compile localGroovy()
 
-    compile 'org.apache.felix:org.apache.felix.scr.generator:1.9.0'
-    compile 'org.apache.felix:org.apache.felix.scr.ds-annotations:1.2.4'
+    compile 'org.apache.felix:org.apache.felix.scr.generator:1.14.0'
+    compile 'org.apache.felix:org.apache.felix.scr.ds-annotations:1.2.8'
     compile 'org.osgi:org.osgi.compendium:5.0.0'
     compile 'org.codehaus.plexus:plexus-utils:3.0.15'
     testCompile 'junit:junit:4.+'


### PR DESCRIPTION
Hi Jan,

Apache Felix SCR Generator 1.10.0 upgraded to ASM 5 which brought Java 8 support. Tested gradle-scr-plugin with version 1.14.0, which works perfectly with Java 8 classes.

Resolves #8.