### PR TITLE
Use compileClasspath for adding dependencies

### DIFF
--- a/src/main/groovy/be/jlrhome/gradle/scr/GenerateDescriptorTask.groovy
+++ b/src/main/groovy/be/jlrhome/gradle/scr/GenerateDescriptorTask.groovy
@@ -18,7 +18,7 @@ class GenerateDescriptorTask extends DefaultTask {
         def dependenciesAsFile = new ArrayList<File>()
         def sources = new ArrayList<Source>()
 
-        project.configurations.compile.resolvedConfiguration.getResolvedArtifacts().each { artifact ->
+        project.configurations.compileClasspath.resolvedConfiguration.getResolvedArtifacts().each { artifact ->
             def f = artifact.getFile()
             dependenciesAsFile.add(f)
             dependenciesAsUrl.add(f.toURI().toURL())


### PR DESCRIPTION
Using `project.configurations.compile` does not work properly if one has `compileOnly` dependencies (which are still needed for `GenerateDescriptorTask` to function; these dependencies are most likely APIs that are implemented by the processed classes).

The task should use the `compileClasspath` configuration which includes all dependencies used during compilation of the processed classes. See https://docs.gradle.org/current/userguide/java_plugin.html#sec:java_plugin_and_dependency_management.